### PR TITLE
Rate limiting-cors

### DIFF
--- a/FinanceEdgeTrack/Application/Services/AuthService.cs
+++ b/FinanceEdgeTrack/Application/Services/AuthService.cs
@@ -125,7 +125,7 @@ public class AuthService : IAuthenticationService
         };
 
         var carteira = await _carteiraService.CreateAsync(carteiraDto);
-        user.CarteiraId = carteira.CarteiraId; 
+        carteira.UserId = user.Id; 
 
         await _userManager.UpdateAsync(user);
 

--- a/FinanceEdgeTrack/Application/Services/DespesaService.cs
+++ b/FinanceEdgeTrack/Application/Services/DespesaService.cs
@@ -6,6 +6,7 @@ using FinanceEdgeTrack.Application.Dtos.Write.Categorias;
 using FinanceEdgeTrack.Domain.Interfaces;
 using FinanceEdgeTrack.Domain.Interfaces.Services;
 using FinanceEdgeTrack.Domain.Models;
+using Mapster;
 using MapsterMapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
@@ -41,19 +42,19 @@ namespace FinanceEdgeTrack.Application.Services
 
         public async Task<ApiResponse<PagedList<DespesaDTO>>> ListarDespesasAsync(PaginationParams pagination)
         {
-            var despesas = await _uof.DespesaRepository.GetAllAsync();
+            var despesas = _uof.DespesaRepository.GetAll();
 
             if (despesas is null)
                 return ApiResponse<PagedList<DespesaDTO>>.Fail(ResultMessages.NotFoundDespesa);
 
             var query = despesas
-                .AsQueryable()
                 .AsNoTracking()
-                .OrderByDescending(d => d.Data);
+                .OrderByDescending(d => d.Data)
+                .ProjectToType<DespesaDTO>();
 
             var despesasPaginadas = await PagedList<DespesaDTO>.CreateAsync
                 (
-                query.Select(d => _mapper.Map<DespesaDTO>(d)),
+                query,
                 pagination.PageNumber,
                 pagination.PageSize
                 );
@@ -63,19 +64,19 @@ namespace FinanceEdgeTrack.Application.Services
 
         public async Task<ApiResponse<PagedList<DespesaDTO>>> DespesasFixasPaginadasAsync(PaginationParams pagination)
         {
-            var despesas = await _uof.DespesaRepository.GetAllAsync();
+            var despesas = _uof.DespesaRepository.GetAll();
 
             if (despesas is null)
                 return ApiResponse<PagedList<DespesaDTO>>.Fail(ResultMessages.NotFoundDespesa);
 
             var query = despesas
-                .AsQueryable()
                 .AsNoTracking()
-                .Where(d => d.Fixa == true);
+                .Where(d => d.Fixa == true)
+                .ProjectToType<DespesaDTO>();
 
             var despesasPaginadas = await PagedList<DespesaDTO>.CreateAsync
                 (
-                query.Select(d => _mapper.Map<DespesaDTO>(d)),
+                query,
                 pagination.PageNumber,
                 pagination.PageSize
                 );
@@ -85,19 +86,19 @@ namespace FinanceEdgeTrack.Application.Services
 
         public async Task<ApiResponse<PagedList<DespesaDTO>>> DespesasFiltradasMaiorValorAsync(PaginationParams pagination)
         {
-            var despesas = await _uof.DespesaRepository.GetAllAsync();
+            var despesas = _uof.DespesaRepository.GetAll();
 
             if (despesas is null)
                 return ApiResponse<PagedList<DespesaDTO>>.Fail(ResultMessages.NotFoundDespesa);
 
             var query = despesas
-                .AsQueryable()
                 .AsNoTracking()
-                .OrderByDescending(d => d.Valor);
+                .OrderByDescending(d => d.Valor)
+                .ProjectToType<DespesaDTO>();
 
             var despesasFiltradas = await PagedList<DespesaDTO>.CreateAsync
                 (
-                query.Select(d => _mapper.Map<DespesaDTO>(d)),
+                query,
                 pagination.PageNumber,
                 pagination.PageSize
                 );
@@ -107,19 +108,19 @@ namespace FinanceEdgeTrack.Application.Services
 
         public async Task<ApiResponse<PagedList<DespesaDTO>>> DespesasFiltradasMenorValorAsync(PaginationParams pagination)
         {
-            var despesas = await _uof.DespesaRepository.GetAllAsync();
+            var despesas = _uof.DespesaRepository.GetAll();
 
             if (despesas is null)
                 return ApiResponse<PagedList<DespesaDTO>>.Fail(ResultMessages.NotFoundDespesa);
 
             var query = despesas
-                .AsQueryable()
                 .AsNoTracking()
-                .OrderBy(d => d.Valor);
+                .OrderBy(d => d.Valor)
+                .ProjectToType<DespesaDTO>();
 
             var despesasFiltradas = await PagedList<DespesaDTO>.CreateAsync
                 (
-                query.Select(d => _mapper.Map<DespesaDTO>(d)),
+                query,
                 pagination.PageNumber,
                 pagination.PageSize
                 );

--- a/FinanceEdgeTrack/Application/Services/LancamentoService.cs
+++ b/FinanceEdgeTrack/Application/Services/LancamentoService.cs
@@ -5,6 +5,7 @@ using FinanceEdgeTrack.Application.Dtos.Write.Lancamentos;
 using FinanceEdgeTrack.Domain.Interfaces;
 using FinanceEdgeTrack.Domain.Interfaces.Services;
 using FinanceEdgeTrack.Domain.Models;
+using Mapster;
 using MapsterMapper;
 using Microsoft.EntityFrameworkCore;
 
@@ -78,19 +79,19 @@ public class LancamentoService : ILancamentoService
 
     public async Task<ApiResponse<PagedList<LancamentoDTO>>> GetAllLancamentosAsync(PaginationParams pagination)
     {
-        var lancamentos = await _uof.LancamentoRepository.GetAllAsync();
+        var lancamentos = _uof.LancamentoRepository.GetAll();
 
         if (lancamentos is null)
             return ApiResponse<PagedList<LancamentoDTO>>.Fail(ResultMessages.NotFoundLancamento);
 
         var query = lancamentos
-           .AsQueryable()
            .AsNoTracking()
-           .OrderBy(l => l.DataLancamento);
+           .OrderBy(l => l.DataLancamento)
+           .ProjectToType<LancamentoDTO>();
 
         var lancamentosPaginados = await PagedList<LancamentoDTO>.CreateAsync
             (
-             query.Select(l => _mapper.Map<LancamentoDTO>(l)),
+             query,
              pagination.PageNumber,
              pagination.PageSize
             );
@@ -101,19 +102,19 @@ public class LancamentoService : ILancamentoService
 
     public async Task<ApiResponse<PagedList<LancamentoDTO>>> GetAllFilterByDataDescendingAsync(PaginationParams pagination)
     {
-        var lancamentos = await _uof.LancamentoRepository.GetAllAsync();
+        var lancamentos = _uof.LancamentoRepository.GetAll();
 
         if (lancamentos is null)
             return ApiResponse<PagedList<LancamentoDTO>>.Fail(ResultMessages.NotFoundLancamento);
 
         var query = lancamentos
-           .AsQueryable()
            .AsNoTracking()
-           .OrderByDescending(l => l.DataLancamento);
+           .OrderByDescending(l => l.DataLancamento)
+           .ProjectToType<LancamentoDTO>();
 
         var lancamentosPaginados = await PagedList<LancamentoDTO>.CreateAsync
             (
-             query.Select(l => _mapper.Map<LancamentoDTO>(l)),
+             query,
              pagination.PageNumber,
              pagination.PageSize
             );

--- a/FinanceEdgeTrack/Application/Services/MetaService.cs
+++ b/FinanceEdgeTrack/Application/Services/MetaService.cs
@@ -52,20 +52,12 @@ public class MetaService : IMetaService
 
     public async Task<ApiResponse<PagedList<AporteMetasDTO>>> GetAllAportesDaMetaPorIdAsync(Guid metaId, PaginationParams pagination)
     {
-        var meta = await _uof.MetaRepository.GetAsync(m => m.MetaId == metaId);
-
-        if (meta is null)
-            return ApiResponse<PagedList<AporteMetasDTO>>.Fail(ResultMessages.NotFoundMeta);
-
-        var aportes = meta.Aportes;
-
-        if (aportes is null)
-            return ApiResponse<PagedList<AporteMetasDTO>>.Fail(ResultMessages.EmptyAporteCollection);
-
-        var query = aportes
-            .AsQueryable()
-            .AsNoTracking()
-            .OrderByDescending(a => a.Valor);
+        var query = _uof.MetaRepository
+        .Query()
+        .Where(m => m.MetaId == metaId)
+        .SelectMany(m => m.Aportes)
+        .OrderByDescending(a => a.Valor)
+        .ProjectToType<AporteMetasDTO>();
 
         var aportesPaginados = await PagedList<AporteMetasDTO>.CreateAsync
             (
@@ -79,19 +71,19 @@ public class MetaService : IMetaService
 
     public async Task<ApiResponse<PagedList<MetaDTO>>> GetAllMetasAsync(PaginationParams pagination)
     {
-        var metas = await _uof.MetaRepository.GetAllAsync();
+        var metas = _uof.MetaRepository.GetAll();
 
         if (metas is null)
             return ApiResponse<PagedList<MetaDTO>>.Fail(ResultMessages.NotFoundMeta);
 
         var query = metas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderByDescending(m => m.DataInicio);
+            .OrderByDescending(m => m.DataInicio)
+            .ProjectToType<MetaDTO>();
 
         var metasPaginadas = await PagedList<MetaDTO>.CreateAsync
             (
-            query.Select(m => _mapper.Map<MetaDTO>(m)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );
@@ -101,19 +93,19 @@ public class MetaService : IMetaService
 
     public async Task<ApiResponse<PagedList<MetaDTO>>> MetasFiltradasMaiorValorAsync(PaginationParams pagination)
     {
-        var metas = await _uof.MetaRepository.GetAllAsync();
+        var metas = _uof.MetaRepository.GetAll();
 
         if (metas is null)
             return ApiResponse<PagedList<MetaDTO>>.Fail(ResultMessages.NotFoundMeta);
 
         var query = metas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderByDescending(m => m.ValorAlvo);
+            .OrderByDescending(m => m.ValorAlvo)
+            .ProjectToType<MetaDTO>();
 
         var metasPaginadas = await PagedList<MetaDTO>.CreateAsync
             (
-            query.Select(m => _mapper.Map<MetaDTO>(m)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );
@@ -123,19 +115,19 @@ public class MetaService : IMetaService
 
     public async Task<ApiResponse<PagedList<MetaDTO>>> MetasFiltradasMenorValorAsync(PaginationParams pagination)
     {
-        var metas = await _uof.MetaRepository.GetAllAsync();
+        var metas = _uof.MetaRepository.GetAll();
 
         if (metas is null)
             return ApiResponse<PagedList<MetaDTO>>.Fail(ResultMessages.NotFoundMeta);
 
         var query = metas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderBy(m => m.ValorAlvo);
+            .OrderBy(m => m.ValorAlvo)
+            .ProjectToType<MetaDTO>();
 
         var metasPaginadas = await PagedList<MetaDTO>.CreateAsync
             (
-            query.Select(m => _mapper.Map<MetaDTO>(m)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );
@@ -145,19 +137,19 @@ public class MetaService : IMetaService
 
     public async Task<ApiResponse<PagedList<MetaDTO>>> MetasFiltradasQuaseConcluidasAsync(PaginationParams pagination)
     {
-        var metas = await _uof.MetaRepository.GetAllAsync();
+        var metas = _uof.MetaRepository.GetAll();
 
         if (metas is null)
             return ApiResponse<PagedList<MetaDTO>>.Fail(ResultMessages.NotFoundMeta);
 
         var query = metas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderByDescending(m => m.ValorAtual);
+            .OrderByDescending(m => m.ValorAtual)
+            .ProjectToType<MetaDTO>();
 
         var metasPaginadas = await PagedList<MetaDTO>.CreateAsync
             (
-            query.Select(m => _mapper.Map<MetaDTO>(m)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );
@@ -167,19 +159,19 @@ public class MetaService : IMetaService
 
     public async Task<ApiResponse<PagedList<MetaDTO>>> MetasFiltradasMaisAntigaAsync(PaginationParams pagination)
     {
-        var metas = await _uof.MetaRepository.GetAllAsync();
+        var metas = _uof.MetaRepository.GetAll();
 
         if (metas is null)
             return ApiResponse<PagedList<MetaDTO>>.Fail(ResultMessages.NotFoundMeta);
 
         var query = metas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderBy(m => m.DataInicio);
+            .OrderBy(m => m.DataInicio)
+            .ProjectToType<MetaDTO>();
 
         var metasPaginadas = await PagedList<MetaDTO>.CreateAsync
             (
-            query.Select(m => _mapper.Map<MetaDTO>(m)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );
@@ -189,19 +181,19 @@ public class MetaService : IMetaService
 
     public async Task<ApiResponse<PagedList<MetaDTO>>> MetasFiltradasMaisRecentesAsync(PaginationParams pagination)
     {
-        var metas = await _uof.MetaRepository.GetAllAsync();
+        var metas = _uof.MetaRepository.GetAll();
 
         if (metas is null)
             return ApiResponse<PagedList<MetaDTO>>.Fail(ResultMessages.NotFoundMeta);
 
         var query = metas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderByDescending(m => m.DataInicio);
+            .OrderByDescending(m => m.DataInicio)
+            .ProjectToType<MetaDTO>();
 
         var metasPaginadas = await PagedList<MetaDTO>.CreateAsync
             (
-            query.Select(m => _mapper.Map<MetaDTO>(m)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );
@@ -211,19 +203,19 @@ public class MetaService : IMetaService
 
     public async Task<ApiResponse<PagedList<MetaDTO>>> MetasFiltradasPorStatusAsync(StatusParams statusPagination)
     {
-        var metas = await _uof.MetaRepository.GetAllAsync();
+        var metas = _uof.MetaRepository.GetAll();
 
         if (metas is null)
             return ApiResponse<PagedList<MetaDTO>>.Fail(ResultMessages.NotFoundMeta);
 
         var query = metas
-            .AsQueryable()
             .AsNoTracking()
-            .Where(m => m.Status == statusPagination.Status);
+            .Where(m => m.Status == statusPagination.Status)
+            .ProjectToType<MetaDTO>();
 
         var metasPaginadas = await PagedList<MetaDTO>.CreateAsync
             (
-            query.Select(m => _mapper.Map<MetaDTO>(m)),
+            query,
             statusPagination.PageNumber,
             statusPagination.PageSize
             );

--- a/FinanceEdgeTrack/Application/Services/ReceitaService.cs
+++ b/FinanceEdgeTrack/Application/Services/ReceitaService.cs
@@ -6,6 +6,7 @@ using FinanceEdgeTrack.Domain.Interfaces;
 using FinanceEdgeTrack.Domain.Interfaces.Repositories;
 using FinanceEdgeTrack.Domain.Interfaces.Services;
 using FinanceEdgeTrack.Domain.Models;
+using Mapster;
 using MapsterMapper;
 using Microsoft.EntityFrameworkCore;
 
@@ -39,19 +40,19 @@ public class ReceitaService : IReceitaService
 
     public async Task<ApiResponse<PagedList<ReceitaDTO>>> ListarReceitasAsync(PaginationParams pagination)
     {
-        var receitas = await _uof.ReceitaRepository.GetAllAsync();
+        var receitas = _uof.ReceitaRepository.GetAll();
 
         if (receitas is null)
             return ApiResponse<PagedList<ReceitaDTO>>.Fail(ResultMessages.NotFoundReceive);
 
         var query = receitas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderByDescending(r => r.Data);
+            .OrderByDescending(r => r.Data)
+            .ProjectToType<ReceitaDTO>();
 
         var receitasPaginadas = await PagedList<ReceitaDTO>.CreateAsync
             (
-            query.Select(r => _mapper.Map<ReceitaDTO>(r)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );
@@ -61,19 +62,19 @@ public class ReceitaService : IReceitaService
 
     public async Task<ApiResponse<PagedList<ReceitaDTO>>> ReceitasFiltradasMaiorValorAsync(PaginationParams pagination)
     {
-        var receitas = await _uof.ReceitaRepository.GetAllAsync();
+        var receitas = _uof.ReceitaRepository.GetAll();
 
         if (receitas is null)
             return ApiResponse<PagedList<ReceitaDTO>>.Fail(ResultMessages.NotFoundReceive);
 
         var query = receitas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderByDescending(r => r.Valor);
+            .OrderByDescending(r => r.Valor)
+            .ProjectToType<ReceitaDTO>();
 
         var receitasPaginadas = await PagedList<ReceitaDTO>.CreateAsync
             (
-            query.Select(r => _mapper.Map<ReceitaDTO>(r)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );
@@ -83,19 +84,19 @@ public class ReceitaService : IReceitaService
 
     public async Task<ApiResponse<PagedList<ReceitaDTO>>> ReceitasFiltradasMenorValorAsync(PaginationParams pagination)
     {
-        var receitas = await _uof.ReceitaRepository.GetAllAsync();
+        var receitas = _uof.ReceitaRepository.GetAll();
 
         if (receitas is null)
             return ApiResponse<PagedList<ReceitaDTO>>.Fail(ResultMessages.NotFoundReceive);
 
         var query = receitas
-            .AsQueryable()
             .AsNoTracking()
-            .OrderBy(r => r.Valor);
+            .OrderBy(r => r.Valor)
+            .ProjectToType<ReceitaDTO>();
 
         var receitasPaginadas = await PagedList<ReceitaDTO>.CreateAsync
             (
-            query.Select(r => _mapper.Map<ReceitaDTO>(r)),
+            query,
             pagination.PageNumber,
             pagination.PageSize
             );

--- a/FinanceEdgeTrack/Controllers/AuthController.cs
+++ b/FinanceEdgeTrack/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
-﻿using FinanceEdgeTrack.Application.Common.Responses;
+﻿using Asp.Versioning;
+using FinanceEdgeTrack.Application.Common.Responses;
 using FinanceEdgeTrack.Application.Dtos.Read.Auth;
 using FinanceEdgeTrack.Application.Dtos.Write.Auth;
 using FinanceEdgeTrack.Domain.Interfaces.Services;

--- a/FinanceEdgeTrack/Controllers/DespesaController.cs
+++ b/FinanceEdgeTrack/Controllers/DespesaController.cs
@@ -1,4 +1,5 @@
-﻿using FinanceEdgeTrack.Application.Common.Pagination;
+﻿using Asp.Versioning;
+using FinanceEdgeTrack.Application.Common.Pagination;
 using FinanceEdgeTrack.Application.Dtos.Read.Categorias;
 using FinanceEdgeTrack.Application.Dtos.Write.Categorias;
 using FinanceEdgeTrack.Domain.Interfaces.Services;
@@ -8,7 +9,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace FinanceEdgeTrack.Controllers;
 
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/v{version:apiVersion}/[controller]")]
+[ApiVersion("1.0")]
 public class DespesaController : ControllerBase
 {
     private readonly IDespesaService _despesaService;

--- a/FinanceEdgeTrack/Controllers/LancamentoController.cs
+++ b/FinanceEdgeTrack/Controllers/LancamentoController.cs
@@ -1,4 +1,5 @@
-﻿using FinanceEdgeTrack.Application.Common.Pagination;
+﻿using Asp.Versioning;
+using FinanceEdgeTrack.Application.Common.Pagination;
 using FinanceEdgeTrack.Application.Dtos.Read.Lancamentos;
 using FinanceEdgeTrack.Application.Dtos.Write.Categorias;
 using FinanceEdgeTrack.Application.Dtos.Write.Lancamentos;
@@ -9,7 +10,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace FinanceEdgeTrack.Controllers;
 
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/v{version:apiVersion}/[controller]")]
+[ApiVersion("1.0")]
 public class LancamentoController : ControllerBase
 {
     private readonly ILancamentoService _lancamentoService;

--- a/FinanceEdgeTrack/Controllers/MetaController.cs
+++ b/FinanceEdgeTrack/Controllers/MetaController.cs
@@ -1,4 +1,5 @@
-﻿using FinanceEdgeTrack.Application.Common.Pagination;
+﻿using Asp.Versioning;
+using FinanceEdgeTrack.Application.Common.Pagination;
 using FinanceEdgeTrack.Application.Common.Pagination.Filters;
 using FinanceEdgeTrack.Application.Dtos.Write.Categorias;
 using FinanceEdgeTrack.Application.Services;
@@ -9,7 +10,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace FinanceEdgeTrack.Controllers;
 
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/v{version:apiVersion}/[controller]")]
+[ApiVersion("1.0")]
 public class MetaController : ControllerBase
 {
     private readonly IMetaService _metaService;

--- a/FinanceEdgeTrack/Controllers/ReceitaController.cs
+++ b/FinanceEdgeTrack/Controllers/ReceitaController.cs
@@ -1,4 +1,5 @@
-﻿using FinanceEdgeTrack.Application.Common.Pagination;
+﻿using Asp.Versioning;
+using FinanceEdgeTrack.Application.Common.Pagination;
 using FinanceEdgeTrack.Application.Dtos.Write.Categorias;
 using FinanceEdgeTrack.Application.Services;
 using FinanceEdgeTrack.Domain.Interfaces.Services;
@@ -7,7 +8,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace FinanceEdgeTrack.Controllers;
 
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/v{version:apiVersion}/[controller]")]
+[ApiVersion("1.0")]
 public class ReceitaController : ControllerBase
 {
     private readonly IReceitaService _receitaService;

--- a/FinanceEdgeTrack/Domain/Interfaces/Repositories/IDespesaRepository.cs
+++ b/FinanceEdgeTrack/Domain/Interfaces/Repositories/IDespesaRepository.cs
@@ -4,6 +4,4 @@ namespace FinanceEdgeTrack.Domain.Interfaces.Repositories;
 
 public interface IDespesaRepository : IRepository<Despesa>
 {
-
-    // métodos com filtros e paginação posteriormente.
 }

--- a/FinanceEdgeTrack/Domain/Interfaces/Repositories/ILancamentoRepository.cs
+++ b/FinanceEdgeTrack/Domain/Interfaces/Repositories/ILancamentoRepository.cs
@@ -5,6 +5,4 @@ namespace FinanceEdgeTrack.Domain.Interfaces.Repositories;
 
 public interface ILancamentoRepository : IRepository<Lancamento>
 {
-
-    // métodos com filtros e paginação posteriormente.
 }

--- a/FinanceEdgeTrack/Domain/Interfaces/Repositories/IMetaRepository.cs
+++ b/FinanceEdgeTrack/Domain/Interfaces/Repositories/IMetaRepository.cs
@@ -4,7 +4,4 @@ namespace FinanceEdgeTrack.Domain.Interfaces.Repositories;
 
 public interface IMetaRepository : IRepository<Meta>
 {
-    // Metas com filtros para: Maior aporte, ultima modificação, pagination.
-
-    // ex: PagedList<Meta> GetMetasPorMaiorAporte();
 }

--- a/FinanceEdgeTrack/Domain/Interfaces/Repositories/IRepository.cs
+++ b/FinanceEdgeTrack/Domain/Interfaces/Repositories/IRepository.cs
@@ -5,7 +5,8 @@ namespace FinanceEdgeTrack.Domain.Interfaces.Repositories;
 public interface IRepository<T>
 {
     Task<T?> GetAsync(Expression<Func<T, bool>> predicate);
-    Task<IEnumerable<T>> GetAllAsync();
+    IQueryable<T> GetAll();
+    IQueryable<T> Query();
     Task<T> CreateAsync(T entity);
     Task<T> UpdateAsync(T entity);
     Task<T> DeleteAsync(T entity);

--- a/FinanceEdgeTrack/Domain/Models/ApplicationUser.cs
+++ b/FinanceEdgeTrack/Domain/Models/ApplicationUser.cs
@@ -17,12 +17,8 @@ public class ApplicationUser : IdentityUser
     [Range(0, 999999999)]
     public decimal ValorTotalGasto { get; set; } = default!;
 
-    // atributo que será atualizado sempre que fizer um lançamento para acompanhar histórico do user
     public int TotalLancamentos { get; set; } = 0;
 
-    public int? CarteiraId { get; set; }
-   
-    [ForeignKey(nameof(CarteiraId))]
     public Carteira? Carteira { get; set; }
 
     [Required]

--- a/FinanceEdgeTrack/FinanceEdgeTrack.csproj
+++ b/FinanceEdgeTrack/FinanceEdgeTrack.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
     <PackageReference Include="Mapster" Version="7.4.0" />
     <PackageReference Include="Mapster.Core" Version="1.2.1" />
     <PackageReference Include="Mapster.DependencyInjection" Version="1.0.1" />

--- a/FinanceEdgeTrack/Infrastructure/Config/CorsOptions.cs
+++ b/FinanceEdgeTrack/Infrastructure/Config/CorsOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace FinanceEdgeTrack.Infrastructure.Config;
+
+public class CorsOptions
+{
+    public string [] AllowedOrigins { get; set; } = [];
+}

--- a/FinanceEdgeTrack/Infrastructure/Config/RateLimitingOptions.cs
+++ b/FinanceEdgeTrack/Infrastructure/Config/RateLimitingOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace FinanceEdgeTrack.Infrastructure.Config;
+
+public class RateLimitingOptions //classe de config fortemente tipada
+{
+    public const string SectionName = "RateLimiting";
+
+    public int AuthenticatedUserLimit { get; set; }
+
+    public int LoginLimit { get; set; }
+
+    public int WindowSeconds { get; set; }
+}

--- a/FinanceEdgeTrack/Infrastructure/Data/AppDbContext.cs
+++ b/FinanceEdgeTrack/Infrastructure/Data/AppDbContext.cs
@@ -90,23 +90,16 @@ public class AppDbContext : IdentityDbContext<ApplicationUser>
 
             entity.Property(s => s.Saldo)
            .HasPrecision(15, 2);
-
-
-            entity.HasOne(c => c.User)
-            .WithOne()
-            .OnDelete(DeleteBehavior.Cascade);
-
         });
 
 
         // User
-        model.Entity<ApplicationUser>(entity =>
-        {
-            entity.HasOne(u => u.Carteira)
-            .WithOne()
-            .OnDelete(DeleteBehavior.Restrict);
+        model.Entity<ApplicationUser>()
+             .HasOne(u => u.Carteira)
+             .WithOne(c => c.User)
+             .HasForeignKey<Carteira>(c => c.UserId)
+             .OnDelete(DeleteBehavior.Cascade);
 
-        });
 
         model.Entity<Lancamento>(entity =>
         {

--- a/FinanceEdgeTrack/Infrastructure/Data/Migrations/20260316154439_FinalMigration.Designer.cs
+++ b/FinanceEdgeTrack/Infrastructure/Data/Migrations/20260316154439_FinalMigration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceEdgeTrack.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceEdgeTrack.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260316154439_FinalMigration")]
+    partial class FinalMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -54,6 +57,9 @@ namespace FinanceEdgeTrack.Migrations
                         .IsRequired()
                         .HasMaxLength(14)
                         .HasColumnType("character varying(14)");
+
+                    b.Property<int?>("CarteiraId")
+                        .HasColumnType("integer");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
@@ -121,6 +127,9 @@ namespace FinanceEdgeTrack.Migrations
                         .HasColumnType("numeric");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("CarteiraId")
+                        .IsUnique();
 
                     b.HasIndex("NormalizedEmail")
                         .HasDatabaseName("EmailIndex");
@@ -437,10 +446,20 @@ namespace FinanceEdgeTrack.Migrations
                     b.Navigation("Meta");
                 });
 
+            modelBuilder.Entity("FinanceEdgeTrack.Domain.Models.ApplicationUser", b =>
+                {
+                    b.HasOne("FinanceEdgeTrack.Domain.Models.Carteira", "Carteira")
+                        .WithOne()
+                        .HasForeignKey("FinanceEdgeTrack.Domain.Models.ApplicationUser", "CarteiraId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.Navigation("Carteira");
+                });
+
             modelBuilder.Entity("FinanceEdgeTrack.Domain.Models.Carteira", b =>
                 {
                     b.HasOne("FinanceEdgeTrack.Domain.Models.ApplicationUser", "User")
-                        .WithOne("Carteira")
+                        .WithOne()
                         .HasForeignKey("FinanceEdgeTrack.Domain.Models.Carteira", "UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
@@ -522,11 +541,6 @@ namespace FinanceEdgeTrack.Migrations
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-                });
-
-            modelBuilder.Entity("FinanceEdgeTrack.Domain.Models.ApplicationUser", b =>
-                {
-                    b.Navigation("Carteira");
                 });
 
             modelBuilder.Entity("FinanceEdgeTrack.Domain.Models.Meta", b =>

--- a/FinanceEdgeTrack/Infrastructure/Data/Migrations/20260316154439_FinalMigration.cs
+++ b/FinanceEdgeTrack/Infrastructure/Data/Migrations/20260316154439_FinalMigration.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceEdgeTrack.Migrations
+{
+    /// <inheritdoc />
+    public partial class FinalMigration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DataConclusao",
+                table: "Metas",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DataConclusao",
+                table: "Metas");
+        }
+    }
+}

--- a/FinanceEdgeTrack/Infrastructure/Data/Migrations/20260316161805_FixUserWallet.Designer.cs
+++ b/FinanceEdgeTrack/Infrastructure/Data/Migrations/20260316161805_FixUserWallet.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FinanceEdgeTrack.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FinanceEdgeTrack.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260316161805_FixUserWallet")]
+    partial class FixUserWallet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FinanceEdgeTrack/Infrastructure/Data/Migrations/20260316161805_FixUserWallet.cs
+++ b/FinanceEdgeTrack/Infrastructure/Data/Migrations/20260316161805_FixUserWallet.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinanceEdgeTrack.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixUserWallet : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AspNetUsers_Carteira_CarteiraId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetUsers_CarteiraId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "CarteiraId",
+                table: "AspNetUsers");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "CarteiraId",
+                table: "AspNetUsers",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUsers_CarteiraId",
+                table: "AspNetUsers",
+                column: "CarteiraId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AspNetUsers_Carteira_CarteiraId",
+                table: "AspNetUsers",
+                column: "CarteiraId",
+                principalTable: "Carteira",
+                principalColumn: "CarteiraId",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/FinanceEdgeTrack/Infrastructure/Extensions/ApiExceptionFilter.cs
+++ b/FinanceEdgeTrack/Infrastructure/Extensions/ApiExceptionFilter.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
-namespace FinanceEdgeTrack.Extensions
+namespace FinanceEdgeTrack.Infrastructure.Extensions
 {
     public class ApiExceptionFilter : ExceptionFilterAttribute
     {

--- a/FinanceEdgeTrack/Infrastructure/Extensions/ApiExtensionMiddleware.cs
+++ b/FinanceEdgeTrack/Infrastructure/Extensions/ApiExtensionMiddleware.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Diagnostics;
 using FinanceEdgeTrack.Error;
 
-namespace FinanceEdgeTrack.Extensions;
+namespace FinanceEdgeTrack.Infrastructure.Extensions;
 
 public static class ApiExtensionMiddleware
 {

--- a/FinanceEdgeTrack/Infrastructure/Extensions/ApiVersioningConfiguration.cs
+++ b/FinanceEdgeTrack/Infrastructure/Extensions/ApiVersioningConfiguration.cs
@@ -1,0 +1,28 @@
+﻿using FinanceEdgeTrack.Infrastructure.Config;
+using System.Runtime.CompilerServices;
+using Asp.Versioning;
+using Asp.Versioning.ApiExplorer;
+
+namespace FinanceEdgeTrack.Infrastructure.Extensions;
+
+public static class ApiVersioningConfiguration
+{
+
+    public static IServiceCollection AddApiVersionConfig(this IServiceCollection service)
+    {
+        service.AddApiVersioning(options =>
+        {
+            options.DefaultApiVersion = new ApiVersion(1, 0);
+            options.AssumeDefaultVersionWhenUnspecified = true;
+            options.ReportApiVersions = true;
+            options.ApiVersionReader = ApiVersionReader.Combine
+                                      (new UrlSegmentApiVersionReader());
+        }).AddApiExplorer(optionsExplorer =>
+        {
+            optionsExplorer.GroupNameFormat = "'v'VVV";
+            optionsExplorer.SubstituteApiVersionInUrl = true;
+        });
+            
+        return service;
+    }
+}

--- a/FinanceEdgeTrack/Infrastructure/Extensions/CorsExtensionMiddleware.cs
+++ b/FinanceEdgeTrack/Infrastructure/Extensions/CorsExtensionMiddleware.cs
@@ -1,0 +1,26 @@
+﻿using FinanceEdgeTrack.Infrastructure.Config;
+
+namespace FinanceEdgeTrack.Infrastructure.Extensions;
+
+public static class CorsExtensionMiddleware
+{
+
+    public static IServiceCollection AddCorsConfiguration(this IServiceCollection service, IConfiguration config)
+    {
+        var corsOptions = config.GetSection("Cors")
+                                .Get<CorsOptions>();
+
+        service.AddCors(options =>
+        {
+            options.AddPolicy("DefaultAllowedCors", policy =>
+            {
+                policy
+                .WithOrigins(corsOptions!.AllowedOrigins)
+                .AllowAnyHeader()
+                .AllowAnyMethod();
+            });
+        });
+
+        return service;
+    }
+}

--- a/FinanceEdgeTrack/Infrastructure/Extensions/RateLimitingExtensionMiddleware.cs
+++ b/FinanceEdgeTrack/Infrastructure/Extensions/RateLimitingExtensionMiddleware.cs
@@ -1,0 +1,27 @@
+﻿using FinanceEdgeTrack.Infrastructure.Config;
+using FinanceEdgeTrack.Infrastructure.RateLimiting;
+using System.Reflection.Metadata.Ecma335;
+using System.Threading.RateLimiting;
+
+namespace FinanceEdgeTrack.Infrastructure.Extensions;
+
+public static class RateLimitingExtensionMiddleware
+{
+    public static IServiceCollection AddApiRateLimiting(
+        this IServiceCollection services, IConfiguration config)
+    {
+        var options = new RateLimitingOptions();
+
+        config.GetSection(RateLimitingOptions.SectionName)
+              .Bind(options);
+
+        services.AddRateLimiter(rateLimiterOptions =>
+        {
+            rateLimiterOptions.GlobalLimiter = RateLimitingPolices.CreateUserLimiter(options);
+
+            rateLimiterOptions.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+        });
+
+        return services;
+    }
+}

--- a/FinanceEdgeTrack/Infrastructure/RateLimiting/RateLimitingPolices.cs
+++ b/FinanceEdgeTrack/Infrastructure/RateLimiting/RateLimitingPolices.cs
@@ -1,0 +1,42 @@
+﻿
+using FinanceEdgeTrack.Infrastructure.Config;
+using System.Security.Claims;
+using System.Threading.RateLimiting;
+
+namespace FinanceEdgeTrack.Infrastructure.RateLimiting;
+
+public static class RateLimitingPolices
+{
+    public static PartitionedRateLimiter<HttpContext> CreateUserLimiter(RateLimitingOptions options)
+    {
+        return PartitionedRateLimiter.Create<HttpContext, string>(context =>
+        {
+            var userId = context.User.FindFirstValue(ClaimTypes.NameIdentifier); // apenas para utilizar e ver se o user está authenticado.
+
+            if (!string.IsNullOrEmpty(userId))
+            {
+                return RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: $"user: {userId}",
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = options.AuthenticatedUserLimit,
+                        Window = TimeSpan.FromSeconds(options.WindowSeconds),
+                        QueueLimit = 3,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst
+                    });
+            }
+
+            var ip = context.Connection.RemoteIpAddress?.ToString() ?? "unknow";
+
+            return RateLimitPartition.GetFixedWindowLimiter(
+                partitionKey: $"login: {ip}",
+                factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = options.LoginLimit,
+                Window = TimeSpan.FromSeconds(options.WindowSeconds),
+                QueueLimit = 0
+            });
+
+        });
+    }
+}

--- a/FinanceEdgeTrack/Infrastructure/Repositories/Repository.cs
+++ b/FinanceEdgeTrack/Infrastructure/Repositories/Repository.cs
@@ -3,6 +3,7 @@ using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using FinanceEdgeTrack.Domain.Interfaces.Repositories;
+using System.Reflection.Metadata.Ecma335;
 
 namespace FinanceEdgeTrack.Infrastructure.Repositories;
 
@@ -15,8 +16,11 @@ public class Repository<T> : IRepository<T> where T : class
         _context = context;
     }
 
-    public async Task<IEnumerable<T>> GetAllAsync()
-        => await _context.Set<T>().ToListAsync();
+    public IQueryable<T> GetAll()
+        => _context.Set<T>();
+
+    public IQueryable<T> Query()
+        => _context.Set<T>();
 
     public async Task<T?> GetAsync(Expression<Func<T, bool>> predicate)
         => await _context.Set<T>().FirstOrDefaultAsync(predicate);

--- a/FinanceEdgeTrack/Program.cs
+++ b/FinanceEdgeTrack/Program.cs
@@ -55,6 +55,9 @@ builder.Services.AddCorsConfiguration(builder.Configuration);
 // Rate Limiting config
 builder.Services.AddApiRateLimiting(builder.Configuration);
 
+// Versioning config
+builder.Services.AddApiVersionConfig();
+
 // Identity
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
     .AddEntityFrameworkStores<AppDbContext>()

--- a/FinanceEdgeTrack/Program.cs
+++ b/FinanceEdgeTrack/Program.cs
@@ -4,7 +4,7 @@ using FinanceEdgeTrack.Domain.Interfaces;
 using FinanceEdgeTrack.Domain.Interfaces.Repositories;
 using FinanceEdgeTrack.Domain.Interfaces.Services;
 using FinanceEdgeTrack.Domain.Models;
-using FinanceEdgeTrack.Extensions;
+using FinanceEdgeTrack.Infrastructure.Extensions;
 using FinanceEdgeTrack.Infrastructure.Config;
 using FinanceEdgeTrack.Infrastructure.Data;
 using FinanceEdgeTrack.Infrastructure.Repositories;
@@ -43,12 +43,23 @@ builder.Configuration
 builder.Services.AddDbContext<AppDbContext>(options =>
 options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 
+// Bind strongly-typed JWT settings
+var jwtSection = builder.Configuration.GetSection("JWT");
+builder.Services.Configure<JwtSettings>(jwtSection);
+var jwtSettings = jwtSection.Get<JwtSettings>() ?? throw new ArgumentException("JWT configuration missing");
+builder.Services.AddSingleton(jwtSettings);
+
+
 
 // Dependency Injections (Services, Mapper, etc...)
 
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
     .AddEntityFrameworkStores<AppDbContext>()
     .AddDefaultTokenProviders();
+
+// Rate Limiting config
+builder.Services.AddApiRateLimiting(builder.Configuration);
+
 
 builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
@@ -62,11 +73,6 @@ builder.Services.AddScoped<ICurrentUserService, CurrentUserService>();
 builder.Services.AddScoped<ITokenService, TokenService>();
 builder.Services.AddScoped<IAuthenticationService, AuthService>();
 
-// Bind strongly-typed JWT settings
-var jwtSection = builder.Configuration.GetSection("JWT");
-builder.Services.Configure<JwtSettings>(jwtSection);
-var jwtSettings = jwtSection.Get<JwtSettings>() ?? throw new ArgumentException("JWT configuration missing");
-builder.Services.AddSingleton(jwtSettings);
 
 // Authentication
 builder.Services.AddAuthentication(options =>
@@ -135,6 +141,14 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseCors();
+
+app.UseRateLimiter();
 
 app.UseAuthorization();
 

--- a/FinanceEdgeTrack/Program.cs
+++ b/FinanceEdgeTrack/Program.cs
@@ -50,16 +50,17 @@ var jwtSettings = jwtSection.Get<JwtSettings>() ?? throw new ArgumentException("
 builder.Services.AddSingleton(jwtSettings);
 
 
+// Rate Limiting config
+builder.Services.AddApiRateLimiting(builder.Configuration);
 
-// Dependency Injections (Services, Mapper, etc...)
 
+// Identity
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
     .AddEntityFrameworkStores<AppDbContext>()
     .AddDefaultTokenProviders();
 
-// Rate Limiting config
-builder.Services.AddApiRateLimiting(builder.Configuration);
 
+// Dependency Injections (Services, Mapper, etc...)
 
 builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/FinanceEdgeTrack/Program.cs
+++ b/FinanceEdgeTrack/Program.cs
@@ -49,10 +49,11 @@ builder.Services.Configure<JwtSettings>(jwtSection);
 var jwtSettings = jwtSection.Get<JwtSettings>() ?? throw new ArgumentException("JWT configuration missing");
 builder.Services.AddSingleton(jwtSettings);
 
+// Cors config
+builder.Services.AddCorsConfiguration(builder.Configuration);
 
 // Rate Limiting config
 builder.Services.AddApiRateLimiting(builder.Configuration);
-
 
 // Identity
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
@@ -147,7 +148,7 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
-app.UseCors();
+app.UseCors("DefaultAllowedCors");
 
 app.UseRateLimiter();
 

--- a/FinanceEdgeTrack/appsettings.json
+++ b/FinanceEdgeTrack/appsettings.json
@@ -16,5 +16,11 @@
     "RefreshTokenValidityInMinutes": 60
   },
 
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+
+  "RateLimiting": {
+    "AuthenticatedUserLimit": 170,
+    "LoginLimit": 5,
+    "WindowSeconds": 30
+  }
 }

--- a/FinanceEdgeTrack/appsettings.json
+++ b/FinanceEdgeTrack/appsettings.json
@@ -22,5 +22,14 @@
     "AuthenticatedUserLimit": 170,
     "LoginLimit": 5,
     "WindowSeconds": 30
+  },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:4200",
+      "http://localhost:3000",
+      "http://localhost:5230",
+      "http://localhost:5432",
+      "https://meufrontend.com"
+    ] 
   }
 }


### PR DESCRIPTION
Correção de relacionamentos entre entidades e feito a implementação de maneira global das políticas CORS e políticas de Rate Limiting para users cadastrados e não cadastrados, assim tendo uma maior proteção contra ataques mal intencionados e controlando o número de requisições em uma janela de tempo, evitando quebrar a aplicação/servidor. 
Além da implementação das configurações de versionamento da API.